### PR TITLE
Added missing coverpoints for JALR.

### DIFF
--- a/sample_cgfs/rv32i_priv.cgf
+++ b/sample_cgfs/rv32i_priv.cgf
@@ -73,7 +73,8 @@ misalign2-jalr:
   opcode:
     jalr: 0
   val_comb:
-    'ea_align == 2': 0
+    'imm_val%2 == 1 and ea_align == 2': 0
+    'imm_val%2 == 0 and ea_align == 2': 0
 
 misalign1-jalr:
   config: 
@@ -81,7 +82,8 @@ misalign1-jalr:
   opcode:
     jalr: 0
   val_comb:
-    'ea_align == 1': 0
+    'imm_val%2 == 1 and ea_align == 1': 0
+    'imm_val%2 == 0 and ea_align == 1': 0
 
 misalign-jal:
   config:


### PR DESCRIPTION
The status of implemented coverpoints for JALR is as follows.

Calculated Address[2:0] | ea_align | Effective Target[2:0] | Base | Offset | CGF node
-- | -- | -- | -- | -- | --
00 | 0 | 00 | EVEN | EVEN | jalr
 | | | | ODD | ODD | jalr
01 | 1 | 00 | ODD | EVEN | misalign1
 | | | | EVEN | ODD | Added recently. "misalign1" node on latest branch in riscv_ctg
10 | 2 | 10 | EVEN | EVEN | misalign2
 | | | | ODD | ODD | Added recently. "misalign2" node on latest branch in riscv_ctg
11 | 3 | 10 | ODD | EVEN | Follows through from ea_align==1 and ea_align==2
 | | | | EVEN | ODD | Follows through ea_align==1 and ea_align==2

