### PR TITLE
Coverpoint update for jalr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,28 @@ jobs:
           
       - name: Run rv32i
         run: riscv_ctg -r -d rv32i -bi rv32i -cf sample_cgfs/dataset.cgf -cf sample_cgfs/rv32i.cgf -v debug -p $(nproc)
+
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: version check
+        run: |
+          export CHNGVER=$(grep -P -o '(?<=## \[).*(?=\])' -m1 CHANGELOG.md); 
+          echo "CHANGELOG VERSION: $CHNGVER"
+          export INITVER=$(grep -P "__version__ = '.*?'" riscv_ctg/__init__.py | awk '{print $3}'|sed "s/'//g"); 
+          echo "INIT VERSION: $INITVER"
+          export TAGVER=$(git describe --tags --abbrev=0);
+          echo "TAGVER: $TAGVER"
+          if [ "$CHNGVER" = "$INITVER" ]; then
+              echo "Versions are equal in Changelog and init.py."
+          else
+              echo "Versions are not equal in Changelog and init.py."
+              exit 1
+          fi
+          if [ "$CHNGVER" = "$TAGVER" ]; then
+              echo "Versions are equal in Changelog and current tag."
+              exit 1
+          else
+              echo "Versions are not equal in Changelog and current tag. Good."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2021-02-23
+- Added missing coverpoints for JALR
+- fixed CI to run main.yml on pushes to master.
+- added version check for PRs in test.yml
+
 ## [0.4.3] - 2021-02-23
 - Updated CI to actions
 

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.4.3'
+__version__ = '0.4.4'

--- a/sample_cgfs/rv32i_priv.cgf
+++ b/sample_cgfs/rv32i_priv.cgf
@@ -73,7 +73,8 @@ misalign2-jalr:
   opcode:
     jalr: 0
   val_comb:
-    'ea_align == 2': 0
+    'imm_val%2 == 1 and ea_align == 2': 0
+    'imm_val%2 == 0 and ea_align == 2': 0
 
 misalign1-jalr:
   config: 
@@ -81,7 +82,8 @@ misalign1-jalr:
   opcode:
     jalr: 0
   val_comb:
-    'ea_align == 1': 0
+    'imm_val%2 == 1 and ea_align == 1': 0
+    'imm_val%2 == 0 and ea_align == 1': 0
 
 misalign-jal:
   config:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.4.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.4.3',
+    version='0.4.4',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
The status of implemented coverpoints for JALR is as follows.

Calculated Address[2:0] | ea_align | Effective Target[2:0] | Base | Offset | CGF node
-- | -- | -- | -- | -- | --
00 | 0 | 00 | EVEN | EVEN | jalr
 | | | | ODD | ODD | jalr
01 | 1 | 00 | ODD | EVEN | misalign1
 | | | | EVEN | ODD | Added recently. "misalign1" node on latest branch in riscv_ctg
10 | 2 | 10 | EVEN | EVEN | misalign2
 | | | | ODD | ODD | Added recently. "misalign2" node on latest branch in riscv_ctg
11 | 3 | 10 | ODD | EVEN | Follows through from ea_align==1 and ea_align==2
 | | | | EVEN | ODD | Follows through ea_align==1 and ea_align==2

